### PR TITLE
Update deprecated API call

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ error_handling.init_app(app)
 AUTHORIZE_URL = 'https://github.com/login/oauth/authorize'
 ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
 ORGS_URL = 'https://api.github.com/user/orgs'
-REVOKE_TOKEN_URL = 'https://api.github.com/applications/{}/tokens/'.format(app.config['GITHUB_CLIENT_ID'])
+REVOKE_TOKEN_URL = 'https://api.github.com/applications/{}/token'.format(app.config['GITHUB_CLIENT_ID'])
 
 
 ###
@@ -134,7 +134,9 @@ def authorized():
                                             'authorization': 'token {}'.format(access_token)})
 
         app.logger.debug("Revoking Github Access Token")
-        d = requests.delete(REVOKE_TOKEN_URL + access_token, auth=(app.config['GITHUB_CLIENT_ID'], app.config['GITHUB_CLIENT_SECRET']))
+        d = requests.delete(REVOKE_TOKEN_URL,
+                            auth=(app.config['GITHUB_CLIENT_ID'], app.config['GITHUB_CLIENT_SECRET']),
+                            data={'access_token': access_token})
         app.logger.debug("(Request returned {})".format(d.status_code))
 
         data = r.json()


### PR DESCRIPTION
This is in response to the following email from GitHub:

> Hello there!
> 
> On March 17th, 2020 at 08:23 (PDT), your application (lil-blog-generator) issued a request using the deprecated form of OAuth Application API that includes access tokens in the URL path. GitHub has deprecated these endpoints and replaced them with a version that accepts access tokens in the request body.
> 
> The deprecated endpoints will be removed on May 5th, 2021 at 4:00 PM UTC.
> 
> Please visit https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint for more information about suggested changes, brownouts, and removal dates.
> 
> Thanks,
> The GitHub Team

I believe the change here is the only such API call in the application; the docs for the new endpoint are at https://developer.github.com/v3/apps/oauth_applications/#delete-an-app-token